### PR TITLE
Fix windows publish action bugs

### DIFF
--- a/.github/workflows/Windows_publish.yml
+++ b/.github/workflows/Windows_publish.yml
@@ -40,7 +40,7 @@ jobs:
           python -m pip install twine delvewheel pybind11 wheel
       - name: Add windows dll
         run: |
-          if( $matrix.python-version == '3.10'){
+          if( '${{ matrix.python-version }}' == '3.10'){
             mkdir "build/lib.win-amd64-cpython-310/brainpylib"
             cp win_dll/*  build/lib.win-amd64-cpython-310/brainpylib
           }

--- a/.github/workflows/Windows_publish.yml
+++ b/.github/workflows/Windows_publish.yml
@@ -50,7 +50,7 @@ jobs:
             mkdir "build/lib.win-amd64-${{ matrix.python-version }}/brainpylib"
             cp win_dll/*  build/lib.win-amd64-${{ matrix.python-version }}/brainpylib
           fi
-      - name:
+#      - name:
 #      - name: Build windows wheel
 #        run: |
 #          python setup.py bdist_wheel

--- a/.github/workflows/Windows_publish.yml
+++ b/.github/workflows/Windows_publish.yml
@@ -39,17 +39,15 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install twine delvewheel pybind11 wheel
       - name: Add windows dll
-        if: ${{ matrix.python-version }} != '3.10'
         run: |
-          ls
-          echo ${{ matrix.python-version }}
-          if [[ ${{ matrix.python-version }} == '3.10' ]]; then
+          if(${{ matrix.python-version }} == '3.10'){
             mkdir "build/lib.win-amd64-cpython-310/brainpylib"
             cp win_dll/*  build/lib.win-amd64-cpython-310/brainpylib
-          else
+          }
+          else{
             mkdir "build/lib.win-amd64-${{ matrix.python-version }}/brainpylib"
             cp win_dll/*  build/lib.win-amd64-${{ matrix.python-version }}/brainpylib
-          fi
+          }
 #      - name:
 #      - name: Build windows wheel
 #        run: |

--- a/.github/workflows/Windows_publish.yml
+++ b/.github/workflows/Windows_publish.yml
@@ -2,6 +2,10 @@ name: Publish Windows wheel to PyPI.org
 on:
   release:
     types: [created]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   pypi:
@@ -35,18 +39,27 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install twine delvewheel pybind11 wheel
       - name: Add windows dll
+        if: ${{ matrix.python-version }} != '3.10'
         run: |
-          mkdir "build/lib.win-amd64-${{ matrix.python-version }}/brainpylib"
-          cp win_dll/*  build/lib.win-amd64-${{ matrix.python-version }}/brainpylib
-      - name: Build windows wheel
-        run: |
-          python setup.py bdist_wheel
-      - name: Publish wheels to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          twine upload dist\brainpylib*.whl
+          ls
+          echo ${{ matrix.python-version }}
+          if [[ ${{ matrix.python-version }} == '3.10' ]]; then
+            mkdir "build/lib.win-amd64-cpython-310/brainpylib"
+            cp win_dll/*  build/lib.win-amd64-cpython-310/brainpylib
+          else
+            mkdir "build/lib.win-amd64-${{ matrix.python-version }}/brainpylib"
+            cp win_dll/*  build/lib.win-amd64-${{ matrix.python-version }}/brainpylib
+          fi
+      - name:
+#      - name: Build windows wheel
+#        run: |
+#          python setup.py bdist_wheel
+#      - name: Publish wheels to PyPI
+#        env:
+#          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+#          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+#        run: |
+#          twine upload dist\brainpylib*.whl
 #      - name: Test brainpylib
 #        run: |
 #          python -m pip install dist\brainpylib-0.1.0-${{ matrix.pep-425-tag }}-win_amd64.whl

--- a/.github/workflows/Windows_publish.yml
+++ b/.github/workflows/Windows_publish.yml
@@ -40,7 +40,7 @@ jobs:
           python -m pip install twine delvewheel pybind11 wheel
       - name: Add windows dll
         run: |
-          if( '${{ matrix.python-version }}' == '3.10'){
+          if( ("${{ matrix.python-version }}").Equals("3.10") ){
             mkdir "build/lib.win-amd64-cpython-310/brainpylib"
             cp win_dll/*  build/lib.win-amd64-cpython-310/brainpylib
           }

--- a/.github/workflows/Windows_publish.yml
+++ b/.github/workflows/Windows_publish.yml
@@ -2,11 +2,7 @@ name: Publish Windows wheel to PyPI.org
 on:
   release:
     types: [created]
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
+    
 jobs:
   pypi:
     strategy:
@@ -48,17 +44,16 @@ jobs:
             mkdir "build/lib.win-amd64-${{ matrix.python-version }}/brainpylib"
             cp win_dll/*  build/lib.win-amd64-${{ matrix.python-version }}/brainpylib
           }
-#      - name:
-#      - name: Build windows wheel
-#        run: |
-#          python setup.py bdist_wheel
-#      - name: Publish wheels to PyPI
-#        env:
-#          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-#          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-#        run: |
-#          twine upload dist\brainpylib*.whl
-#      - name: Test brainpylib
-#        run: |
-#          python -m pip install dist\brainpylib-0.1.0-${{ matrix.pep-425-tag }}-win_amd64.whl
-#          pytest brainpylib\
+      - name: Build windows wheel
+        run: |
+          python setup.py bdist_wheel
+      - name: Publish wheels to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          twine upload dist\brainpylib*.whl
+      - name: Test brainpylib
+        run: |
+          python -m pip install dist\brainpylib-0.1.0-${{ matrix.pep-425-tag }}-win_amd64.whl
+          pytest brainpylib\

--- a/.github/workflows/Windows_publish.yml
+++ b/.github/workflows/Windows_publish.yml
@@ -40,7 +40,7 @@ jobs:
           python -m pip install twine delvewheel pybind11 wheel
       - name: Add windows dll
         run: |
-          if(${{ matrix.python-version }} == '3.10'){
+          if( $matrix.python-version == '3.10'){
             mkdir "build/lib.win-amd64-cpython-310/brainpylib"
             cp win_dll/*  build/lib.win-amd64-cpython-310/brainpylib
           }

--- a/.github/workflows/Windows_publish.yml
+++ b/.github/workflows/Windows_publish.yml
@@ -2,7 +2,7 @@ name: Publish Windows wheel to PyPI.org
 on:
   release:
     types: [created]
-    
+
 jobs:
   pypi:
     strategy:
@@ -53,7 +53,3 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           twine upload dist\brainpylib*.whl
-      - name: Test brainpylib
-        run: |
-          python -m pip install dist\brainpylib-0.1.0-${{ matrix.pep-425-tag }}-win_amd64.whl
-          pytest brainpylib\


### PR DESCRIPTION
Fix windows publish action bugs

Py3.10 will create a folder with a different name: 'build\lib.win-amd64-cpython-310\brainpylib'